### PR TITLE
Fixed SVG elements parsing

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -192,11 +192,7 @@ Parser.prototype.onclosetag = function(name){
 };
 
 Parser.prototype.onselfclosingtag = function(){
-	if(this._options.xmlMode || this._options.recognizeSelfClosing){
-		this._closeCurrentTag();
-	} else {
-		this.onopentagend();
-	}
+	this._closeCurrentTag();
 };
 
 Parser.prototype._closeCurrentTag = function(){

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -76,18 +76,7 @@ var voidElements = {
 	param: true,
 	source: true,
 	track: true,
-	wbr: true,
-
-	//common self closing svg elements
-	path: true,
-	circle: true,
-	ellipse: true,
-	line: true,
-	rect: true,
-	use: true,
-	stop: true,
-	polyline: true,
-	polygone: true
+	wbr: true
 };
 
 var re_nameEnd = /\s|\//;

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -3,7 +3,7 @@ var Tokenizer = require("./Tokenizer.js");
 /*
 	Options:
 
-	xmlMode: Special behavior for script/style tags (true by default)
+	xmlMode: Special behavior for script/style tags (false by default)
 	lowerCaseAttributeNames: call .toLowerCase for each attribute name (true if xmlMode is `false`)
 	lowerCaseTags: call .toLowerCase for each tag name (true if xmlMode is `false`)
 */

--- a/test/Events/32-svg_nested.json
+++ b/test/Events/32-svg_nested.json
@@ -1,0 +1,82 @@
+{
+  "name": "Nested SVG element",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<svg><use xlink:href=/icon.svg><title>SVG Icon</title></use></svg>",
+  "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "svg",
+        {}
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "xlink:href",
+        "/icon.svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "use",
+        {
+          "xlink:href": "/icon.svg"
+        }
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "title"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "title",
+        {}
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "SVG Icon"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "title"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "svg"
+      ]
+    }
+  ]
+}

--- a/test/Events/33-svg_self_closing.json
+++ b/test/Events/33-svg_self_closing.json
@@ -1,0 +1,85 @@
+{
+  "name": "Self-closing SVG element",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<svg><use xlink:href=/background.svg /><use xlink:href=/icon.svg /></svg>",
+  "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "svg",
+        {}
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "xlink:href",
+        "/background.svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "use",
+        {
+          "xlink:href": "/background.svg"
+        }
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "xlink:href",
+        "/icon.svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "use",
+        {
+          "xlink:href": "/icon.svg"
+        }
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "svg"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR contains two changes to fix the current SVG elements parsing.

First is remove all SVG elements from `voidElements` list. Almost all SVG elements have content model except for [`hkern`, `vkern`](http://www.w3.org/TR/SVG/fonts.html#KernElements) and [`font-face-name`](http://www.w3.org/TR/SVG/fonts.html#FontFaceNameElement) elements. So they can't always be self-closing elements.

Second is always close self-closing tags. So all SVG elements which may come in two form `<foo />` and `<foo></foo>` can be closed properly.

Some more read in http://www.w3.org/TR/html5/syntax.html#elements-0:

> **Void elements**
>     area, base, br, col, embed, hr, img, input, keygen, link, meta, param, source, track, wbr
> **Raw text elements**
>     script, style
> **escapable raw text elements**
>     textarea, title
> **Foreign elements**
>     Elements from the MathML namespace and the SVG namespace.
> **Normal elements**
>     All other allowed HTML elements are normal elements.
> 
> Tags are used to delimit the start and end of elements in the markup. Raw text, escapable raw text, and normal elements have a start tag to indicate where they begin, and an end tag to indicate where they end. The start and end tags of certain normal elements can be omitted, as described below in the section on optional tags. Those that cannot be omitted must not be omitted. Void elements only have a start tag; end tags must not be specified for void elements. Foreign elements must either have a start tag and an end tag, or a start tag that is marked as self-closing, in which case they must not have an end tag.

In HTML5, self-closing tag is only available for foreign elements (SVG elements). So `<p/>Foo</p>` means `<p>Foo</p>` (1), but `<use xlink:href=/background.svg />` means `<use xlink:href=/background.svg></use>` (2). We can't support both (1) and (2). If we support (1), we can't parse SVG elements correctly. If we drop (1) and support (2), we can deal with most cases, (1) becomes something like `<p></p><p>Foo</p>`. But (1) is quite a rare case.

Also to fully support SVG elements, we must set `lowerCaseAttributeNames` and `lowerCaseTags` options to false because SVG elements is case-sensitive.
