### PR TITLE
Removed all SVG elements from the void elements list

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -76,18 +76,7 @@ var voidElements = {
 	param: true,
 	source: true,
 	track: true,
-	wbr: true,
-
-	//common self closing svg elements
-	path: true,
-	circle: true,
-	ellipse: true,
-	line: true,
-	rect: true,
-	use: true,
-	stop: true,
-	polyline: true,
-	polygone: true
+	wbr: true
 };
 
 var re_nameEnd = /\s|\//;


### PR DESCRIPTION
https://github.com/fb55/htmlparser2/blob/master/lib/Parser.js#L81-L90

```
//common self closing svg elements
path: true,
circle: true,
ellipse: true,
line: true,
rect: true,
use: true,
stop: true,
polyline: true,
polygone: true
```

These SVG elements are not void nor self-closing elements so we need to remove them from the `voidElements` list. After this change, the parser would not parse SVG elements properly unless you set `recognizeSelfClosing = true`.

https://github.com/anvoz/htmlparser2/pull/1 is a possible fix after this PR.
